### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/cslunetta/fe3bf054-f4b7-422c-b32a-414044d596b3/db189144-a81c-49f8-98ba-25a342943808/_apis/work/boardbadge/d06c8f18-3a9d-49fc-b5c9-c6b45c69117b)](https://dev.azure.com/cslunetta/fe3bf054-f4b7-422c-b32a-414044d596b3/_boards/board/t/db189144-a81c-49f8-98ba-25a342943808/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/cslunetta/fe3bf054-f4b7-422c-b32a-414044d596b3/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.